### PR TITLE
Fix dark mode input text color

### DIFF
--- a/src/app/combat/page.tsx
+++ b/src/app/combat/page.tsx
@@ -34,14 +34,14 @@ export default function CombatPage() {
       <h1 className="text-2xl font-bold mb-4">Combat Tracker</h1>
       <div className="flex gap-2 mb-4">
         <input
-          className="border p-1"
+          className="border p-1 text-black"
           placeholder="Enemy"
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
         <input
           type="number"
-          className="border p-1 w-20"
+          className="border p-1 w-20 text-black"
           value={hp}
           onChange={(e) => setHp(parseInt(e.target.value))}
         />

--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -19,7 +19,7 @@ export default function NotesPage() {
     <div>
       <h1 className="text-2xl font-bold mb-4">Notes</h1>
       <textarea
-        className="w-full h-96 p-2 border"
+        className="w-full h-96 p-2 border text-black"
         value={notes}
         onChange={(e) => setNotes(e.target.value)}
       />

--- a/src/app/players/page.tsx
+++ b/src/app/players/page.tsx
@@ -34,14 +34,14 @@ export default function PlayersPage() {
       <h1 className="text-2xl font-bold mb-4">Players</h1>
       <div className="flex gap-2 mb-4">
         <input
-          className="border p-1"
+          className="border p-1 text-black"
           placeholder="Name"
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
         <input
           type="number"
-          className="border p-1 w-20"
+          className="border p-1 w-20 text-black"
           value={hp}
           onChange={(e) => setHp(parseInt(e.target.value))}
         />


### PR DESCRIPTION
## Summary
- ensure input and textarea text is visible on dark mode

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684131d45d148332aabd6653751e6aa2