### PR TITLE
Add enemy state management

### DIFF
--- a/src/app/combat/page.tsx
+++ b/src/app/combat/page.tsx
@@ -1,32 +1,17 @@
 'use client'
 import { useState } from 'react'
-
-interface Enemy {
-  id: number
-  name: string
-  hp: number
-}
+import { useEnemies } from '../../context/EnemiesContext'
 
 export default function CombatPage() {
-  const [enemies, setEnemies] = useState<Enemy[]>([])
+  const { enemies, addEnemy, adjustHp, removeEnemy } = useEnemies()
   const [name, setName] = useState('')
   const [hp, setHp] = useState(10)
 
-  const addEnemy = () => {
+  const handleAddEnemy = () => {
     if (!name) return
-    setEnemies((prev) => [...prev, { id: Date.now(), name, hp }])
+    addEnemy({ id: Date.now(), name, hp })
     setName('')
     setHp(10)
-  }
-
-  const adjustHp = (id: number, delta: number) => {
-    setEnemies((prev) =>
-      prev.map((e) => (e.id === id ? { ...e, hp: e.hp + delta } : e))
-    )
-  }
-
-  const removeEnemy = (id: number) => {
-    setEnemies((prev) => prev.filter((e) => e.id !== id))
   }
 
   return (
@@ -45,7 +30,7 @@ export default function CombatPage() {
           value={hp}
           onChange={(e) => setHp(parseInt(e.target.value))}
         />
-        <button className="bg-blue-500 text-white px-2" onClick={addEnemy}>
+        <button className="bg-blue-500 text-white px-2" onClick={handleAddEnemy}>
           Add
         </button>
       </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import './globals.css'
 import Link from 'next/link'
 import { PlayersProvider } from '../context/PlayersContext'
+import { EnemiesProvider } from '../context/EnemiesContext'
 
 export const metadata: Metadata = {
   title: 'DMShield - A tool for Dungeon Masters',
@@ -17,13 +18,15 @@ export default function RootLayout({
     <html lang="en">
       <body>
         <PlayersProvider>
-          <nav className="bg-gray-800 text-white p-4 flex gap-4">
-            <Link href="/">Home</Link>
-            <Link href="/notes">Notes</Link>
-            <Link href="/players">Players</Link>
-            <Link href="/combat">Combat</Link>
-          </nav>
-          <div className="p-4">{children}</div>
+          <EnemiesProvider>
+            <nav className="bg-gray-800 text-white p-4 flex gap-4">
+              <Link href="/">Home</Link>
+              <Link href="/notes">Notes</Link>
+              <Link href="/players">Players</Link>
+              <Link href="/combat">Combat</Link>
+            </nav>
+            <div className="p-4">{children}</div>
+          </EnemiesProvider>
         </PlayersProvider>
       </body>
     </html>

--- a/src/context/EnemiesContext.tsx
+++ b/src/context/EnemiesContext.tsx
@@ -1,0 +1,62 @@
+'use client'
+import { createContext, useContext, useEffect, useState } from 'react'
+
+export interface Enemy {
+  id: number
+  name: string
+  hp: number
+}
+
+interface EnemiesContextValue {
+  enemies: Enemy[]
+  addEnemy: (enemy: Enemy) => void
+  adjustHp: (id: number, delta: number) => void
+  removeEnemy: (id: number) => void
+}
+
+const EnemiesContext = createContext<EnemiesContextValue | undefined>(undefined)
+
+export function EnemiesProvider({ children }: { children: React.ReactNode }) {
+  const [enemies, setEnemies] = useState<Enemy[]>([])
+
+  useEffect(() => {
+    const stored = localStorage.getItem('dmshield.enemies')
+    if (stored) {
+      try {
+        setEnemies(JSON.parse(stored))
+      } catch (e) {
+        console.error('Failed to parse stored enemies', e)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem('dmshield.enemies', JSON.stringify(enemies))
+  }, [enemies])
+
+  const addEnemy = (enemy: Enemy) => {
+    setEnemies(prev => [...prev, enemy])
+  }
+
+  const adjustHp = (id: number, delta: number) => {
+    setEnemies(prev => prev.map(e => (e.id === id ? { ...e, hp: e.hp + delta } : e)))
+  }
+
+  const removeEnemy = (id: number) => {
+    setEnemies(prev => prev.filter(e => e.id !== id))
+  }
+
+  return (
+    <EnemiesContext.Provider value={{ enemies, addEnemy, adjustHp, removeEnemy }}>
+      {children}
+    </EnemiesContext.Provider>
+  )
+}
+
+export function useEnemies() {
+  const ctx = useContext(EnemiesContext)
+  if (!ctx) {
+    throw new Error('useEnemies must be used within an EnemiesProvider')
+  }
+  return ctx
+}


### PR DESCRIPTION
## Summary
- add `EnemiesContext` for storing enemies in localStorage
- wrap layout with `EnemiesProvider`
- use enemy context in the combat tracker

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684134dc201c8332a9582bc04a3738cb