### PR TITLE
Add dark theme with Tailwind

### DIFF
--- a/src/app/combat/page.tsx
+++ b/src/app/combat/page.tsx
@@ -15,38 +15,38 @@ export default function CombatPage() {
   }
 
   return (
-    <div>
+    <div className="max-w-4xl mx-auto">
       <h1 className="text-2xl font-bold mb-4">Combat Tracker</h1>
       <div className="flex gap-2 mb-4">
         <input
-          className="border p-1 text-black"
+          className="border border-gray-600 bg-gray-800 text-gray-100 p-1 rounded"
           placeholder="Enemy"
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
         <input
           type="number"
-          className="border p-1 w-20 text-black"
+          className="border border-gray-600 bg-gray-800 text-gray-100 p-1 w-20 rounded"
           value={hp}
           onChange={(e) => setHp(parseInt(e.target.value))}
         />
-        <button className="bg-blue-500 text-white px-2" onClick={handleAddEnemy}>
+        <button className="bg-blue-600 hover:bg-blue-700 text-white px-3 rounded" onClick={handleAddEnemy}>
           Add
         </button>
       </div>
       <ul>
         {enemies.map((e) => (
-          <li key={e.id} className="mb-2 flex items-center gap-2">
+          <li key={e.id} className="mb-2 flex items-center gap-2 bg-gray-800 p-2 rounded">
             <span className="font-semibold mr-2">{e.name}</span>
             <button
-              className="px-2 bg-gray-200"
+              className="px-2 bg-gray-700 rounded"
               onClick={() => adjustHp(e.id, -1)}
             >
               -
             </button>
             <span>{e.hp} hp</span>
             <button
-              className="px-2 bg-gray-200"
+              className="px-2 bg-gray-700 rounded"
               onClick={() => adjustHp(e.id, 1)}
             >
               +

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,26 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  --foreground-rgb: 0, 0, 0;
-  --background-start-rgb: 214, 219, 220;
-  --background-end-rgb: 255, 255, 255;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
-  }
-}
-
 body {
-  color: rgb(var(--foreground-rgb));
-  background: linear-gradient(
-      to bottom,
-      transparent,
-      rgb(var(--background-end-rgb))
-    )
-    rgb(var(--background-start-rgb));
+  @apply bg-gray-900 text-gray-100 min-h-screen;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,17 +15,17 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en">
-      <body>
+    <html lang="en" className="dark">
+      <body className="bg-gray-900 text-gray-100 min-h-screen">
         <PlayersProvider>
           <EnemiesProvider>
-            <nav className="bg-gray-800 text-white p-4 flex gap-4">
+            <nav className="bg-gray-800 text-gray-100 p-4 flex gap-4 border-b border-gray-700">
               <Link href="/">Home</Link>
               <Link href="/notes">Notes</Link>
               <Link href="/players">Players</Link>
               <Link href="/combat">Combat</Link>
             </nav>
-            <div className="p-4">{children}</div>
+            <div className="p-4 max-w-4xl mx-auto">{children}</div>
           </EnemiesProvider>
         </PlayersProvider>
       </body>

--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -16,10 +16,10 @@ export default function NotesPage() {
   }, [notes])
 
   return (
-    <div>
+    <div className="max-w-4xl mx-auto">
       <h1 className="text-2xl font-bold mb-4">Notes</h1>
       <textarea
-        className="w-full h-96 p-2 border text-black"
+        className="w-full h-96 p-2 rounded bg-gray-800 border border-gray-600 text-gray-100"
         value={notes}
         onChange={(e) => setNotes(e.target.value)}
       />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,9 +2,9 @@
 
 export default function Home() {
   return (
-    <div>
-      <h1 className="text-3xl font-bold mb-4">DMShield</h1>
-      <p>Use the navigation above to access notes, players and combat trackers.</p>
+    <div className="max-w-2xl mx-auto py-8 text-center">
+      <h1 className="text-4xl font-bold mb-4">DMShield</h1>
+      <p className="text-gray-300">Use the navigation above to access notes, players and combat trackers.</p>
     </div>
   )
 }

--- a/src/app/players/page.tsx
+++ b/src/app/players/page.tsx
@@ -15,38 +15,38 @@ export default function PlayersPage() {
   }
 
   return (
-    <div>
+    <div className="max-w-4xl mx-auto">
       <h1 className="text-2xl font-bold mb-4">Players</h1>
       <div className="flex gap-2 mb-4">
         <input
-          className="border p-1 text-black"
+          className="border border-gray-600 bg-gray-800 text-gray-100 p-1 rounded"
           placeholder="Name"
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
         <input
           type="number"
-          className="border p-1 w-20 text-black"
+          className="border border-gray-600 bg-gray-800 text-gray-100 p-1 w-20 rounded"
           value={hp}
           onChange={(e) => setHp(parseInt(e.target.value))}
         />
-        <button className="bg-blue-500 text-white px-2" onClick={handleAddPlayer}>
+        <button className="bg-blue-600 hover:bg-blue-700 text-white px-3 rounded" onClick={handleAddPlayer}>
           Add
         </button>
       </div>
       <ul>
         {players.map((p) => (
-          <li key={p.id} className="mb-2 flex items-center gap-2">
+          <li key={p.id} className="mb-2 flex items-center gap-2 bg-gray-800 p-2 rounded">
             <span className="font-semibold mr-2">{p.name}</span>
             <button
-              className="px-2 bg-gray-200"
+              className="px-2 bg-gray-700 rounded"
               onClick={() => adjustHp(p.id, -1)}
             >
               -
             </button>
             <span>{p.hp} hp</span>
             <button
-              className="px-2 bg-gray-200"
+              className="px-2 bg-gray-700 rounded"
               onClick={() => adjustHp(p.id, 1)}
             >
               +

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,6 +6,7 @@ const config: Config = {
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
+  darkMode: 'class',
   theme: {
     extend: {
       backgroundImage: {


### PR DESCRIPTION
## Summary
- enable class-based dark mode in Tailwind config
- simplify global CSS and apply dark background
- update layout navigation and container styles
- style pages and forms with dark Tailwind classes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684135ed94ac8332bd89b5b700152ab0