### PR TITLE
Implement basic note management

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css'
 import Link from 'next/link'
 import { PlayersProvider } from '../context/PlayersContext'
 import { EnemiesProvider } from '../context/EnemiesContext'
+import { NotesProvider } from '../context/NotesContext'
 
 export const metadata: Metadata = {
   title: 'DMShield - A tool for Dungeon Masters',
@@ -19,13 +20,15 @@ export default function RootLayout({
       <body className="bg-gray-900 text-gray-100 min-h-screen">
         <PlayersProvider>
           <EnemiesProvider>
-            <nav className="bg-gray-800 text-gray-100 p-4 flex gap-4 border-b border-gray-700">
-              <Link href="/">Home</Link>
-              <Link href="/notes">Notes</Link>
-              <Link href="/players">Players</Link>
-              <Link href="/combat">Combat</Link>
-            </nav>
-            <div className="p-4 max-w-4xl mx-auto">{children}</div>
+            <NotesProvider>
+              <nav className="bg-gray-800 text-gray-100 p-4 flex gap-4 border-b border-gray-700">
+                <Link href="/">Home</Link>
+                <Link href="/notes">Notes</Link>
+                <Link href="/players">Players</Link>
+                <Link href="/combat">Combat</Link>
+              </nav>
+              <div className="p-4 max-w-4xl mx-auto">{children}</div>
+            </NotesProvider>
           </EnemiesProvider>
         </PlayersProvider>
       </body>

--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -1,28 +1,70 @@
 'use client'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
+import { useNotes } from '../../context/NotesContext'
 
 export default function NotesPage() {
-  const [notes, setNotes] = useState('')
+  const { notes, addNote } = useNotes()
+  const [title, setTitle] = useState('')
+  const [content, setContent] = useState('')
+  const [selectedId, setSelectedId] = useState<number | null>(null)
 
-  useEffect(() => {
-    const stored = localStorage.getItem('dmshield.notes')
-    if (stored) {
-      setNotes(stored)
-    }
-  }, [])
+  const handleAdd = () => {
+    if (!title && !content) return
+    addNote({ id: Date.now(), title, content })
+    setTitle('')
+    setContent('')
+  }
 
-  useEffect(() => {
-    localStorage.setItem('dmshield.notes', notes)
-  }, [notes])
+  const selected = notes.find(n => n.id === selectedId)
 
   return (
-    <div className="max-w-4xl mx-auto">
-      <h1 className="text-2xl font-bold mb-4">Notes</h1>
-      <textarea
-        className="w-full h-96 p-2 rounded bg-gray-800 border border-gray-600 text-gray-100"
-        value={notes}
-        onChange={(e) => setNotes(e.target.value)}
-      />
+    <div className="max-w-4xl mx-auto space-y-4">
+      <h1 className="text-2xl font-bold">Notes</h1>
+      <div className="flex flex-col gap-2 bg-gray-800 p-3 rounded border border-gray-700">
+        <input
+          className="border border-gray-600 bg-gray-900 text-gray-100 p-1 rounded"
+          placeholder="Title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+        <textarea
+          className="border border-gray-600 bg-gray-900 text-gray-100 p-1 rounded h-32"
+          placeholder="Content"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+        />
+        <button
+          className="bg-blue-600 hover:bg-blue-700 text-white px-3 rounded self-start"
+          onClick={handleAdd}
+        >
+          Save Note
+        </button>
+      </div>
+
+      <div>
+        {notes.length === 0 ? (
+          <p className="text-gray-400">No notes yet.</p>
+        ) : (
+          <ul className="space-y-1">
+            {notes.map((n) => (
+              <li
+                key={n.id}
+                className="cursor-pointer text-blue-400 hover:underline"
+                onClick={() => setSelectedId(n.id)}
+              >
+                {n.title}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {selected && (
+        <div className="border-t border-gray-700 pt-4">
+          <h2 className="text-xl font-bold mb-2">{selected.title}</h2>
+          <p className="whitespace-pre-wrap">{selected.content}</p>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,19 +1,14 @@
 'use client'
 
-import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { usePlayers } from '../context/PlayersContext'
 import { useEnemies } from '../context/EnemiesContext'
+import { useNotes } from '../context/NotesContext'
 
 export default function Home() {
   const { players } = usePlayers()
   const { enemies } = useEnemies()
-  const [notes, setNotes] = useState('')
-
-  useEffect(() => {
-    const stored = localStorage.getItem('dmshield.notes')
-    if (stored) setNotes(stored)
-  }, [])
+  const { notes } = useNotes()
 
   return (
     <div className="py-8">
@@ -62,12 +57,14 @@ export default function Home() {
             <h2 className="text-xl font-bold">Notes</h2>
             <Link href="/notes" className="text-blue-400 text-sm">Open</Link>
           </div>
-          {notes ? (
-            <div className="text-sm whitespace-pre-wrap max-h-60 overflow-y-auto">
-              {notes}
-            </div>
-          ) : (
+          {notes.length === 0 ? (
             <p className="text-gray-400 text-sm">No notes yet.</p>
+          ) : (
+            <ul className="text-sm space-y-1 max-h-60 overflow-y-auto">
+              {notes.map((n) => (
+                <li key={n.id}>{n.title}</li>
+              ))}
+            </ul>
           )}
         </div>
       </div>

--- a/src/context/NotesContext.tsx
+++ b/src/context/NotesContext.tsx
@@ -1,0 +1,62 @@
+'use client'
+import { createContext, useContext, useEffect, useState } from 'react'
+
+export interface Note {
+  id: number
+  title: string
+  content: string
+}
+
+interface NotesContextValue {
+  notes: Note[]
+  addNote: (note: Note) => void
+  removeNote: (id: number) => void
+  updateNote: (note: Note) => void
+}
+
+const NotesContext = createContext<NotesContextValue | undefined>(undefined)
+
+export function NotesProvider({ children }: { children: React.ReactNode }) {
+  const [notes, setNotes] = useState<Note[]>([])
+
+  useEffect(() => {
+    const stored = localStorage.getItem('dmshield.notes')
+    if (stored) {
+      try {
+        setNotes(JSON.parse(stored))
+      } catch (e) {
+        console.error('Failed to parse stored notes', e)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem('dmshield.notes', JSON.stringify(notes))
+  }, [notes])
+
+  const addNote = (note: Note) => {
+    setNotes(prev => [...prev, note])
+  }
+
+  const removeNote = (id: number) => {
+    setNotes(prev => prev.filter(n => n.id !== id))
+  }
+
+  const updateNote = (note: Note) => {
+    setNotes(prev => prev.map(n => (n.id === note.id ? note : n)))
+  }
+
+  return (
+    <NotesContext.Provider value={{ notes, addNote, removeNote, updateNote }}>
+      {children}
+    </NotesContext.Provider>
+  )
+}
+
+export function useNotes() {
+  const ctx = useContext(NotesContext)
+  if (!ctx) {
+    throw new Error('useNotes must be used within a NotesProvider')
+  }
+  return ctx
+}


### PR DESCRIPTION
## Summary
- add NotesContext for storing notes with titles
- wrap app with `NotesProvider`
- display note titles on the home page
- implement forum-style notes page with create and view functionality

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684138fb90488332a0164caff67ac56b