### PR TITLE
Make homepage lists scrollable

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,7 +27,7 @@ export default function Home() {
           {players.length === 0 ? (
             <p className="text-gray-400 text-sm">No players added.</p>
           ) : (
-            <ul className="text-sm space-y-1">
+            <ul className="text-sm space-y-1 max-h-60 overflow-y-auto pr-2">
               {players.map(p => (
                 <li key={p.id} className="flex justify-between">
                   <span>{p.name}</span>
@@ -46,7 +46,7 @@ export default function Home() {
           {enemies.length === 0 ? (
             <p className="text-gray-400 text-sm">No enemies tracked.</p>
           ) : (
-            <ul className="text-sm space-y-1">
+            <ul className="text-sm space-y-1 max-h-60 overflow-y-auto pr-2">
               {enemies.map(e => (
                 <li key={e.id} className="flex justify-between">
                   <span>{e.name}</span>


### PR DESCRIPTION
## Summary
- keep players and enemies list from expanding the home page

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684139568454833291ab2bfb207c223f