### PR TITLE
Add create note button with toggle form

### DIFF
--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -7,12 +7,14 @@ export default function NotesPage() {
   const [title, setTitle] = useState('')
   const [content, setContent] = useState('')
   const [openId, setOpenId] = useState<number | null>(null)
+  const [showForm, setShowForm] = useState(false)
 
   const handleAdd = () => {
     if (!title && !content) return
     addNote({ id: Date.now(), title, content })
     setTitle('')
     setContent('')
+    setShowForm(false)
   }
 
   const handleDelete = (id: number) => {
@@ -25,26 +27,43 @@ export default function NotesPage() {
   return (
     <div className="max-w-4xl mx-auto space-y-4">
       <h1 className="text-2xl font-bold">Notes</h1>
-      <div className="flex flex-col gap-2 bg-gray-800 p-3 rounded border border-gray-700">
-        <input
-          className="border border-gray-600 bg-gray-900 text-gray-100 p-1 rounded"
-          placeholder="Title"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-        />
-        <textarea
-          className="border border-gray-600 bg-gray-900 text-gray-100 p-1 rounded h-32"
-          placeholder="Content"
-          value={content}
-          onChange={(e) => setContent(e.target.value)}
-        />
+      {!showForm ? (
         <button
-          className="bg-blue-600 hover:bg-blue-700 text-white px-3 rounded self-start"
-          onClick={handleAdd}
+          className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded"
+          onClick={() => setShowForm(true)}
         >
-          Save Note
+          Create Note
         </button>
-      </div>
+      ) : (
+        <div className="flex flex-col gap-2 bg-gray-800 p-3 rounded border border-gray-700">
+          <input
+            className="border border-gray-600 bg-gray-900 text-gray-100 p-1 rounded"
+            placeholder="Title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+          <textarea
+            className="border border-gray-600 bg-gray-900 text-gray-100 p-1 rounded h-32"
+            placeholder="Content"
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+          />
+          <div className="flex gap-2">
+            <button
+              className="bg-blue-600 hover:bg-blue-700 text-white px-3 rounded"
+              onClick={handleAdd}
+            >
+              Save Note
+            </button>
+            <button
+              className="bg-gray-700 hover:bg-gray-600 text-white px-3 rounded"
+              onClick={() => setShowForm(false)}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
 
       <div>
         {notes.length === 0 ? (


### PR DESCRIPTION
## Summary
- add toggleable form for creating notes
- hide form until `Create Note` is clicked

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68413d2c44b48332888a732e2be2292e