### PR TITLE
Move DMShield header to nav bar

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,8 +21,8 @@ export default function RootLayout({
         <PlayersProvider>
           <EnemiesProvider>
             <NotesProvider>
-              <nav className="bg-gray-800 text-gray-100 p-4 flex gap-4 border-b border-gray-700">
-                <Link href="/">Home</Link>
+              <nav className="bg-gray-800 text-gray-100 p-4 flex items-center gap-4 border-b border-gray-700">
+                <Link href="/" className="text-xl font-bold mr-4">DMShield</Link>
                 <Link href="/notes">Notes</Link>
                 <Link href="/players">Players</Link>
                 <Link href="/combat">Combat</Link>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,6 @@ export default function Home() {
 
   return (
     <div className="py-8">
-      <h1 className="text-4xl font-bold mb-6 text-center">DMShield</h1>
       <div className="grid md:grid-cols-3 gap-4">
         <div className="bg-gray-800 p-4 rounded border border-gray-700">
           <div className="flex items-baseline justify-between mb-2">


### PR DESCRIPTION
## Summary
- reposition the DMShield header into the main nav bar
- remove the standalone page header

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68413e69bbbc8332ba3edb9929ae3c84